### PR TITLE
support upnp portforward

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ options:
   -v              verbose mode, printing debug messages
   -q              exit when mapped address is changed
   -u              UDP mode
+  -f              Add port forwarding through UPNP device.
+                  which maybe improve the mapping success rate under NAT Type 2/3 networks
   -k <interval>   seconds between each keep-alive
   -s <address>    hostname or address to STUN server
   -h <address>    hostname or address to keep-alive server
@@ -97,12 +99,17 @@ Expose local port 80 to the Internet, using iptables kernel forward method (requ
 sudo python3 natter.py -m iptables -p 80
 ```
 
+If you need port mapping via UPnP
+```bash
+python3 natter.py -p 80 -f
+```
+
 
 ## Dependencies
 
 - Python 2.7 (minimum), >= 3.6 (recommended)
 - No third-party modules are required.
-
+- If you need UPnP port mapping function, you need to install upnpcclient. `pip install upnpclient`
 
 ## License
 


### PR DESCRIPTION
# 特性
通过第三方UPnP库upnpclient,支持添加UPnP端口转发,在本地测试通过。
通过 UPnP 直接通过路由器转发到本地实际服务的端口，Natter只负责端口发现和KeepAlive保持端口映射。

# 测试环境
路由器：RedMi AX3000T 
固件版本：1.0.64
脚本运行环境：Debian 11
网络环境：中国广东 / 中国移动 / 路由器拨号
NAT类型： 路由器 NAT 1 / 设备 NAT 3

#测试结果
![natter](https://github.com/MikeWang000000/Natter/assets/107363939/021a57f1-6490-457c-bb64-8fde72e5b385)

# 可能存在问题
1. UPnP 规则生存时间问题，目前设置无限期。或有潜在风险。
        一般路由器重启后会清空规则。通过KeepAlive部分去更新转发规则或许可行。

2. 多个路由器情况下只会添加第一个发现的路由器设备，或许会导致映射失败。

3. 其他品牌路由器可能存在不兼容的情况。需要更多场景测试。

4. 实际入站请求转发请求和出站NAT映射不对等。某些情况下或有可能会影响KeepAlive功能。

